### PR TITLE
add get_tracking_numbers method

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,35 @@ tracking_number = get_tracking_number("1ZY0X1930320121606")
 #    )
 ```
 
+### `get_tracking_numbers(number)`
+
+Parses the `number` and returns all possible corresponding `TrackingNumber` dataclasses
+
+```python
+from tracking_numbers import get_tracking_numbers
+
+tracking_numbers = get_tracking_numbers("93001109246000000072710271")
+
+# => [
+#        TrackingNumber(
+#            valid=True,
+#            number="93001109246000000072710271",
+#            serial_number=[9, 3, 0, 0, 1, 1, 0, 9, 2, 4],
+#            tracking_url="http://www.dhl.com/en/express/tracking.html?brand=DHL&AWB=93001109246000000072710271",
+#            courier=Courier(code="dhl", name="DHL"),
+#            product=Product(name="DHL Express Air"),
+#        ),
+#        TrackingNumber(
+#            valid=True,
+#            number="93001109246000000072710271",
+#            serial_number=[9, 3, 0, 0, 1, 1, 0, 9, 2, 4, 6, 0, 0, 0, 0, 0, 0, 0, 7, 2, 7, 1, 0, 2, 7],
+#            tracking_url="https://tools.usps.com/go/TrackConfirmAction?tLabels=93001109246000000072710271",
+#            courier=Courier(code="usps", name="United States Postal Service"),
+#            product=Product(name="USPS 91"),
+#        )
+# ]
+```
+
 ### `get_definition(product_name)`
 
 Given a product name, gets the `TrackingNumberDefinition` associated.

--- a/tracking_numbers/__init__.py
+++ b/tracking_numbers/__init__.py
@@ -28,3 +28,15 @@ def get_definition(product_name: str) -> Optional[TrackingNumberDefinition]:
             return tn_definition
 
     return None
+
+
+def get_tracking_numbers(number: str) -> list[TrackingNumber]:
+    """
+    Parses the `number` and returns all possible corresponding `TrackingNumber` dataclasses
+    """
+    candidates = []
+    for tn_definition in DEFINITIONS:
+        tracking_number = tn_definition.test(number)
+        if tracking_number and tracking_number.valid:
+            candidates.append(tracking_number)
+    return candidates

--- a/tracking_numbers/__init__.py
+++ b/tracking_numbers/__init__.py
@@ -31,9 +31,6 @@ def get_definition(product_name: str) -> Optional[TrackingNumberDefinition]:
 
 
 def get_tracking_numbers(number: str) -> list[TrackingNumber]:
-    """
-    Parses the `number` and returns all possible corresponding `TrackingNumber` dataclasses
-    """
     candidates = []
     for tn_definition in DEFINITIONS:
         tracking_number = tn_definition.test(number)


### PR DESCRIPTION
Firstly, thank you for creating this package! I've been looking for a python-implementation of `jkeens` spec for a while. 

Currently, `get_tracking_number` returns the first valid `TrackingNumber` based on a given `number`. However, I'd like to be able to get *all* matching `TrackingNumber`s (with differing couriers) and add some logic to select the most appropriate courier afterwards. I've added a new function `get_tracking_numbers(number: str) -> list[TrackingNumber]` which does exactly this. Let me know what you think!